### PR TITLE
[hotfix] Prevent empty playerId or spectatorId in create methods.

### DIFF
--- a/src/server/datastore/ephemeral.test.ts
+++ b/src/server/datastore/ephemeral.test.ts
@@ -200,6 +200,20 @@ describe('player', () => {
             )
         );
     });
+    it('create new player with falsy ID', () => {
+        const datastore = new EphemeralDataStore();
+
+        const player = datastore.createPlayer('');
+
+        assert.notEqual(player.playerId, '');
+
+        assert.deepStrictEqual(
+            Object.keys(player),
+            Object.keys(
+                loadYaml(readFileSync(`${__dirname}/scheme.yaml`)).player
+            )
+        );
+    });
     it('find player', () => {
         const datastore = new EphemeralDataStore();
 
@@ -248,6 +262,20 @@ describe('spectator', () => {
         const spectator = datastore.createSpectator();
 
         assert.ok(spectator.spectatorId);
+
+        assert.deepStrictEqual(
+            Object.keys(spectator),
+            Object.keys(
+                loadYaml(readFileSync(`${__dirname}/scheme.yaml`)).spectator
+            )
+        );
+    });
+    it('create new spectator with falsy ID', () => {
+        const datastore = new EphemeralDataStore();
+
+        const spectator = datastore.createSpectator('');
+
+        assert.notEqual(spectator.spectatorId, '');
 
         assert.deepStrictEqual(
             Object.keys(spectator),

--- a/src/server/datastore/ephemeral.ts
+++ b/src/server/datastore/ephemeral.ts
@@ -92,9 +92,9 @@ export class EphemeralDataStore implements DataStore {
         return;
     }
 
-    createPlayer(playerId = uuidv4()): Player {
+    createPlayer(playerId?: string): Player {
         const player = {
-            playerId,
+            playerId: playerId || uuidv4(),
             name: ''
         };
 
@@ -124,9 +124,9 @@ export class EphemeralDataStore implements DataStore {
         return player;
     }
 
-    createSpectator(spectatorId = uuidv4()): Spectator {
+    createSpectator(spectatorId?: string): Spectator {
         const spectator = {
-            spectatorId,
+            spectatorId: spectatorId || uuidv4(),
             name: ''
         };
 


### PR DESCRIPTION
Added tests.