### PR TITLE
[hotfix] Set gameId and playerId as optional.

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -19,16 +19,19 @@ export class WebSocketGameLobbyClient {
     }: {
         port: number;
         options?: any;
-        gameId: string;
-        playerId: string;
+        gameId?: string;
+        playerId?: string;
     }) {
         this.wss = new ReconnectingWebSocket(
             `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${
                 window.location.hostname
-            }${port ? `:${port}` : ''}?${qs.stringify({
-                gameId,
-                playerId
-            })}`,
+            }${port ? `:${port}` : ''}?${qs.stringify(
+                {
+                    gameId,
+                    playerId
+                },
+                { skipNulls: true }
+            )}`,
             [],
             options
         );


### PR DESCRIPTION
Skip nulls when building WebSocket URL.